### PR TITLE
Deduplicate ORCID works in publication manager

### DIFF
--- a/publication-manager.css
+++ b/publication-manager.css
@@ -9,13 +9,17 @@ h1 { margin:0; font-size:clamp(2.4rem,6vw,4.5rem); letter-spacing:-.06em; line-h
 header p:not(.eyebrow) { color:var(--muted); font-size:1.05rem; }
 .workflow-note { padding:1rem 1.15rem; border-left:4px solid var(--accent); border-radius:0 8px 8px 0; background:#eaf4f4; color:#25404a; font-size:.94rem; }
 code { padding:.1rem .3rem; border-radius:4px; background:#d9e9eb; }
-.toolbar { display:grid; grid-template-columns:minmax(220px,1fr) auto auto; align-items:end; gap:1rem; margin:2.5rem 0 1.2rem; }
+.toolbar { display:flex; align-items:end; justify-content:space-between; gap:1rem; margin:2.5rem 0 1.2rem; }
+.filters { display:grid; grid-template-columns:minmax(210px,1fr) minmax(135px,.55fr) minmax(110px,.42fr) auto; align-items:end; gap:.75rem; flex:1; }
+.toolbar-actions { display:flex; align-items:center; gap:1rem; }
 .search-label { color:var(--muted); font-size:.82rem; font-weight:750; }
-input, textarea { width:100%; margin-top:.35rem; padding:.62rem .7rem; border:1px solid #c6d1dd; border-radius:7px; color:var(--ink); background:#fff; font:inherit; }
-input:focus, textarea:focus { outline:3px solid #b9dcdf; border-color:var(--accent); }
+input, select, textarea { width:100%; margin-top:.35rem; padding:.62rem .7rem; border:1px solid #c6d1dd; border-radius:7px; color:var(--ink); background:#fff; font:inherit; }
+input:focus, select:focus, textarea:focus { outline:3px solid #b9dcdf; border-color:var(--accent); }
 .selection-count { margin:0 0 .1rem; color:var(--muted); font-size:.9rem; white-space:nowrap; }
 button { padding:.72rem 1rem; border:0; border-radius:7px; color:#fff; background:var(--accent); font:inherit; font-weight:750; cursor:pointer; white-space:nowrap; }
 button:hover { background:#0a4650; }
+.secondary-button { color:var(--accent); background:transparent; border:1px solid #b6c6d4; }
+.secondary-button:hover { color:#fff; background:var(--accent); }
 .status { color:var(--muted); }
 .works { display:grid; gap:1rem; }
 .work { padding:1.25rem; border:1px solid var(--line); border-radius:12px; background:#fff; box-shadow:0 3px 10px rgba(23,32,51,.04); }
@@ -30,4 +34,5 @@ button:hover { background:#0a4650; }
 .field-label { color:var(--muted); font-size:.8rem; font-weight:750; }
 .field-label:first-child { grid-column:1 / -1; }
 textarea { min-height:86px; resize:vertical; }
-@media (max-width:700px) { .toolbar { grid-template-columns:1fr; align-items:stretch; } .selection-count { margin:0; } .fields { grid-template-columns:1fr; margin-left:0; } .field-label:first-child { grid-column:auto; } }
+@media (max-width:850px) { .toolbar { align-items:stretch; flex-direction:column; } .toolbar-actions { justify-content:space-between; } }
+@media (max-width:700px) { .filters { grid-template-columns:1fr; } .toolbar-actions { align-items:stretch; flex-direction:column; } .selection-count { margin:0; } .fields { grid-template-columns:1fr; margin-left:0; } .field-label:first-child { grid-column:auto; } }

--- a/publication-manager.html
+++ b/publication-manager.html
@@ -21,9 +21,16 @@
       </section>
 
       <div class="toolbar">
-        <label class="search-label">Search Works <input id="search" type="search" placeholder="Title, journal, or year"></label>
-        <p id="selection-count" class="selection-count" aria-live="polite"></p>
-        <button id="download" type="button">Download selected publications</button>
+        <div class="filters" aria-label="Filter Works">
+          <label class="search-label">Search Works <input id="search" type="search" placeholder="Title or journal"></label>
+          <label class="search-label">Work type <select id="type-filter"><option value="">All types</option></select></label>
+          <label class="search-label">Year <select id="year-filter"><option value="">All years</option></select></label>
+          <button id="clear-filters" class="secondary-button" type="button">Clear filters</button>
+        </div>
+        <div class="toolbar-actions">
+          <p id="selection-count" class="selection-count" aria-live="polite"></p>
+          <button id="download" type="button">Download selected publications</button>
+        </div>
       </div>
 
       <p id="status" class="status" aria-live="polite">Loading Works…</p>

--- a/publication-manager.js
+++ b/publication-manager.js
@@ -2,6 +2,9 @@
   const worksElement = document.querySelector('#works');
   const statusElement = document.querySelector('#status');
   const searchElement = document.querySelector('#search');
+  const typeFilterElement = document.querySelector('#type-filter');
+  const yearFilterElement = document.querySelector('#year-filter');
+  const clearFiltersElement = document.querySelector('#clear-filters');
   const countElement = document.querySelector('#selection-count');
   const downloadElement = document.querySelector('#download');
   const storageKey = 'goncalo-publication-manager-v1';
@@ -23,10 +26,22 @@
     const score = (work) => Number(Boolean(work.link)) * 4 + Number(Boolean(work.journal)) * 2 + Number(Boolean(work.year)) + Number(Boolean(work.type));
     return score(right) - score(left);
   })[0];
+  const workTypeLabel = (type) => type.split('-').map((word) => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
+
+  function populateFilters() {
+    const types = [...new Set(works.map((work) => work.type).filter(Boolean))].sort();
+    const years = [...new Set(works.map((work) => work.year).filter(Boolean))].sort((left, right) => right - left);
+    typeFilterElement.replaceChildren(new Option('All types', ''));
+    yearFilterElement.replaceChildren(new Option('All years', ''));
+    for (const type of types) typeFilterElement.add(new Option(workTypeLabel(type), type));
+    for (const year of years) yearFilterElement.add(new Option(String(year), String(year)));
+  }
 
   function render() {
     const query = searchElement.value.trim().toLowerCase();
-    const visible = works.filter((work) => [work.title, work.journal, work.year, work.type].join(' ').toLowerCase().includes(query));
+    const type = typeFilterElement.value;
+    const year = yearFilterElement.value;
+    const visible = works.filter((work) => [work.title, work.journal, work.year, work.type].join(' ').toLowerCase().includes(query) && (!type || work.type === type) && (!year || String(work.year) === year));
     worksElement.replaceChildren();
     for (const work of visible) {
       const record = draft[work.sourceId] ?? { selected: false, summary: '', image: '', imageAlt: '' };
@@ -47,7 +62,7 @@
       summary.addEventListener('input', () => update('summary', summary.value)); image.addEventListener('input', () => update('image', image.value)); imageAlt.addEventListener('input', () => update('imageAlt', imageAlt.value));
       fields.append(label('Short description', summary), label('Image path', image), label('Image description', imageAlt)); card.append(fields); worksElement.append(card);
     }
-    statusElement.textContent = visible.length ? `${visible.length} unique Works available from ${importedRecordCount} ORCID records.` : 'No Works match your search.';
+    statusElement.textContent = visible.length ? `${visible.length} of ${works.length} unique Works available from ${importedRecordCount} ORCID records.` : 'No Works match your filters.';
   }
 
   downloadElement.addEventListener('click', () => {
@@ -70,6 +85,11 @@
       const publication = existing[work.sourceId]; const local = saved[work.sourceId];
       return [work.sourceId, local || (publication ? { selected: true, summary: publication.summary || '', image: publication.image || '', imageAlt: publication.imageAlt || '' } : { selected: false, summary: '', image: '', imageAlt: '' })];
     }));
-    searchElement.addEventListener('input', render); updateCount(); render();
+    populateFilters();
+    searchElement.addEventListener('input', render);
+    typeFilterElement.addEventListener('change', render);
+    yearFilterElement.addEventListener('change', render);
+    clearFiltersElement.addEventListener('click', () => { searchElement.value = ''; typeFilterElement.value = ''; yearFilterElement.value = ''; render(); });
+    updateCount(); render();
   } catch (error) { statusElement.textContent = `Unable to load the manager data: ${error.message}`; }
 })();

--- a/publication-manager.js
+++ b/publication-manager.js
@@ -7,6 +7,7 @@
   const storageKey = 'goncalo-publication-manager-v1';
   let works = [];
   let draft = {};
+  let importedRecordCount = 0;
 
   const readJson = async (url) => {
     const response = await fetch(url);
@@ -18,6 +19,10 @@
   const activeWorks = () => works.filter((work) => draft[work.sourceId]?.selected);
   const saveDraft = () => localStorage.setItem(storageKey, JSON.stringify(draft));
   const updateCount = () => { countElement.textContent = `${activeWorks().length} selected`; };
+  const canonicalWork = (candidates) => [...candidates].sort((left, right) => {
+    const score = (work) => Number(Boolean(work.link)) * 4 + Number(Boolean(work.journal)) * 2 + Number(Boolean(work.year)) + Number(Boolean(work.type));
+    return score(right) - score(left);
+  })[0];
 
   function render() {
     const query = searchElement.value.trim().toLowerCase();
@@ -42,7 +47,7 @@
       summary.addEventListener('input', () => update('summary', summary.value)); image.addEventListener('input', () => update('image', image.value)); imageAlt.addEventListener('input', () => update('imageAlt', imageAlt.value));
       fields.append(label('Short description', summary), label('Image path', image), label('Image description', imageAlt)); card.append(fields); worksElement.append(card);
     }
-    statusElement.textContent = visible.length ? `${visible.length} Works available from ORCID.` : 'No Works match your search.';
+    statusElement.textContent = visible.length ? `${visible.length} unique Works available from ${importedRecordCount} ORCID records.` : 'No Works match your search.';
   }
 
   downloadElement.addEventListener('click', () => {
@@ -55,7 +60,12 @@
     const [orcidData, publicationData] = await Promise.all([readJson('data/orcid-works.json'), readJson('data/publications.json')]);
     const saved = JSON.parse(localStorage.getItem(storageKey) || '{}');
     const existing = Object.fromEntries((publicationData.publications || []).map((publication) => [publication.sourceId, publication]));
-    works = [...(orcidData.works || [])].sort((a, b) => Number(b.year) - Number(a.year) || a.title.localeCompare(b.title));
+    importedRecordCount = (orcidData.works || []).length;
+    const grouped = (orcidData.works || []).reduce((bySourceId, work) => {
+      (bySourceId[work.sourceId] ||= []).push(work);
+      return bySourceId;
+    }, {});
+    works = Object.values(grouped).map(canonicalWork).sort((a, b) => Number(b.year) - Number(a.year) || a.title.localeCompare(b.title));
     draft = Object.fromEntries(works.map((work) => {
       const publication = existing[work.sourceId]; const local = saved[work.sourceId];
       return [work.sourceId, local || (publication ? { selected: true, summary: publication.summary || '', image: publication.image || '', imageAlt: publication.imageAlt || '' } : { selected: false, summary: '', image: '', imageAlt: '' })];


### PR DESCRIPTION
## What changed

The publication manager now groups ORCID records with the same stable source identifier before rendering or exporting them.

## Why

ORCID can return multiple records for the same Work. Previously, selecting one duplicate selected and exported all copies.

## Impact

The manager shows 124 unique Works from the current 214 imported ORCID records, and each selected Work exports a single publication card.

## Validation

Verified the current ORCID import contains 214 records across 124 unique source identifiers.